### PR TITLE
Release/v3.0.0 beta 0.4

### DIFF
--- a/.devilbox/www/config.php
+++ b/.devilbox/www/config.php
@@ -13,8 +13,8 @@ error_reporting(-1);
 putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1');
 
 
-$DEVILBOX_VERSION = 'v3.0.0-beta-0.3';
-$DEVILBOX_DATE = '2023-01-02';
+$DEVILBOX_VERSION = 'v3.0.0-beta-0.4';
+$DEVILBOX_DATE = '2023-01-30';
 $DEVILBOX_API_PAGE = 'devilbox-api/status.json';
 
 //

--- a/.devilbox/www/htdocs/cnc.php
+++ b/.devilbox/www/htdocs/cnc.php
@@ -2,31 +2,39 @@
 <?php loadClass('Helper')->authPage(); ?>
 <?php
 // TODO: This is currently a temporary hack to talk to supervisor on the HTTPD server
-function run_supervisor_command($command) {
-	$supervisor_config_file = '/tmp/supervisorctl.conf';
-	$port = getenv('SVCTL_LISTEN_PORT');
-	$user = getenv('SVCTL_USER');
-	$pass = getenv('SVCTL_PASS');
+function run_supervisor_command($host, $command) {
+	if ($host == 'httpd') {
+		$supervisor_config_file = '/tmp/supervisorctl.conf';
+		$port = getenv('SVCTL_LISTEN_PORT');
+		$user = getenv('SVCTL_USER');
+		$pass = getenv('SVCTL_PASS');
 
-	$content = "[supervisorctl]\n";
-	$content .= "serverurl=http://httpd:" . $port . "\n";
-	$content .= "username=" . $user . "\n";
-	$content .= "password=" . $pass . "\n";
+		$content = "[supervisorctl]\n";
+		$content .= "serverurl=http://httpd:" . $port . "\n";
+		$content .= "username=" . $user . "\n";
+		$content .= "password=" . $pass . "\n";
 
-	$fp = fopen($supervisor_config_file, 'w');
-	fwrite($fp, $content);
-	fclose($fp);
+		$fp = fopen($supervisor_config_file, 'w');
+		fwrite($fp, $content);
+		fclose($fp);
 
-	return loadClass('Helper')->exec('supervisorctl -c ' . $supervisor_config_file . ' ' . $command);
+		return loadClass('Helper')->exec('supervisorctl -c ' . $supervisor_config_file . ' ' . $command);
+	} else if ($host == 'php') {
+		return loadClass('Helper')->exec('sudo supervisorctl ' . $command);
+	}
 }
 
 
 ?>
-<?php if ( isset($_POST['watcherd']) && $_POST['watcherd'] == 'reload' ) {
-	run_supervisor_command('restart watcherd');
-	sleep(1);
-	loadClass('Helper')->redirect('/cnc.php');
-}
+<?php
+	if ( isset($_POST['watcherd']) && $_POST['watcherd'] == 'reload' ) {
+		run_supervisor_command('httpd', 'restart watcherd');
+		sleep(1);
+		loadClass('Helper')->redirect('/cnc.php');
+	} else if ( isset($_POST['php-fpm']) && $_POST['php-fpm'] == 'reload' ) {
+		run_supervisor_command('php', 'restart php-fpm');
+		loadClass('Helper')->redirect('/cnc.php');
+	}
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -46,8 +54,9 @@ function run_supervisor_command($command) {
 				<div class="col-md-12">
 
 					<?php
-						$status_w = run_supervisor_command('status watcherd');
-						$status_h = run_supervisor_command('status httpd');
+						$status_w = run_supervisor_command('httpd', 'status watcherd');
+						$status_h = run_supervisor_command('httpd', 'status httpd');
+						$status_p = run_supervisor_command('php',   'status php-fpm');
 
 						$words = preg_split("/\s+/", $status_w);
 						$data_w = array(
@@ -63,32 +72,53 @@ function run_supervisor_command($command) {
 							'pid'    => isset($words[3]) ? preg_replace('/,$/', '', $words[3]) : '',
 							'uptime' => isset($words[5]) ? $words[5] : '',
 						);
+						$words = preg_split("/\s+/", $status_p);
+						$data_p = array(
+							'name'   => isset($words[0]) ? $words[0] : '',
+							'state'  => isset($words[1]) ? $words[1] : '',
+							'pid'    => isset($words[3]) ? preg_replace('/,$/', '', $words[3]) : '',
+							'uptime' => isset($words[5]) ? $words[5] : '',
+						);
 					?>
 					<h3>Daemon overview</h3><br/>
-					<p>If you made any changes to vhost settings (vhost-gen templates or backend configuration) or to the webserver configuration itself, you can trigger a manual reload of <code>watcherd</code> here to apply them. No need to restart the Docker Compose stack.</p>
 					<table class="table table-striped">
 						<thead class="thead-inverse">
 							<tr>
 								<th>Daemon</th>
+								<th>Container</th>
 								<th>Status</th>
 								<th>Pid</th>
 								<th>Uptime</th>
+								<th>Info</th>
 								<th>Action</th>
 							</tr>
 						</thead>
 						<tbody>
 							<tr>
-								<td><?php echo $data_w['name']; ?></td>
+								<td><code><?php echo $data_p['name']; ?></code></td>
+								<td>php</td>
+								<td><?php echo $data_p['state']; ?></td>
+								<td><?php echo $data_p['pid']; ?></td>
+								<td><?php echo $data_p['uptime']; ?></td>
+								<td><a href="#"><i class="fa fa-info" aria-hidden="true" data-toggle="modal" data-target="#info-php-fpm"></i></a></td>
+								<td><form method="post"><button type="submit" name="php-fpm" value="reload" class="btn btn-primary">Reload</button></form></td>
+							</tr>
+							<tr>
+								<td><code><?php echo $data_w['name']; ?></code></td>
+								<td>httpd</td>
 								<td><?php echo $data_w['state']; ?></td>
 								<td><?php echo $data_w['pid']; ?></td>
 								<td><?php echo $data_w['uptime']; ?></td>
+								<td><a href="#"><i class="fa fa-info" aria-hidden="true" data-toggle="modal" data-target="#info-watcherd"></i></a></td>
 								<td><form method="post"><button type="submit" name="watcherd" value="reload" class="btn btn-primary">Reload</button></form></td>
 							</tr>
 							<tr>
-								<td><?php echo $data_h['name']; ?></td>
+								<td><code><?php echo $data_h['name']; ?></code></td>
+								<td>httpd</td>
 								<td><?php echo $data_h['state']; ?></td>
 								<td><?php echo $data_h['pid']; ?></td>
 								<td><?php echo $data_h['uptime']; ?></td>
+								<td></td>
 								<td></td>
 							</tr>
 						</tbody>
@@ -99,7 +129,7 @@ function run_supervisor_command($command) {
 					<h3>watcherd stderr</h3>
 					<br/>
 					<?php
-						$output = run_supervisor_command('tail -1000000 watcherd stderr');
+						$output = run_supervisor_command('httpd', 'tail -1000000 watcherd stderr');
 						echo '<pre>';
 						foreach(preg_split("/((\r?\n)|(\r\n?))/", $output) as $line) {
 							if ( strpos($line, "[ERR]") !== false ) {
@@ -120,7 +150,7 @@ function run_supervisor_command($command) {
 					<h3>watcherd stdout</h3>
 					<br/>
 					<?php
-						$output = run_supervisor_command('tail -1000000 watcherd');
+						$output = run_supervisor_command('httpd', 'tail -1000000 watcherd');
 						echo '<pre>';
 						foreach(preg_split("/((\r?\n)|(\r\n?))/", $output) as $line) {
 							$pos_info = strpos($line, "[INFO]");
@@ -141,6 +171,47 @@ function run_supervisor_command($command) {
 			</div>
 
 		</div><!-- /.container -->
+
+		<!-- Modals (php-fpm) -->
+		<div class="modal fade" id="info-php-fpm" tabindex="-1" role="dialog" aria-labelledby="info-php-fpmLabel" aria-hidden="true">
+		  <div class="modal-dialog" role="document">
+			<div class="modal-content">
+			  <div class="modal-header">
+				<h5 class="modal-title" id="info-php-fpmLabel">Reload <code>php-fpm</code></h5>
+				<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+				  <span aria-hidden="true">&times;</span>
+				</button>
+			  </div>
+			  <div class="modal-body">
+				<p>If you made any changes to PHP such as adding/altering <code>php.ini</code> or <code>php-fpm.conf</code> configuration files (e.g.: Xdebug or other settings), you can trigger a manual restart of the <code>php-fpm</code> process to apply your changes.</p>
+				<p>Reloading php-fpm will apply those changes immediately. There is no need to restart docker compose.</p>
+			  </div>
+			  <div class="modal-footer">
+				<button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+			  </div>
+			</div>
+		  </div>
+		</div>
+		<!-- Modals (php-fpm) -->
+		<div class="modal fade" id="info-watcherd" tabindex="-1" role="dialog" aria-labelledby="info-watcherdLabel" aria-hidden="true">
+		  <div class="modal-dialog" role="document">
+			<div class="modal-content">
+			  <div class="modal-header">
+				<h5 class="modal-title" id="info-watcherdLabel">Reload <code>watcherd</code></h5>
+				<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+				  <span aria-hidden="true">&times;</span>
+				</button>
+			  </div>
+			  <div class="modal-body">
+				<p>If you have made any changes to vhost settings such as adding/altering custom vhost-gen templates, backend configuration or changes to the webserver itself, you can trigger a manual reload of <code>watcherd</code>.</p>
+				<p>Reloading watcherd will update all vhosts based and your configuration and reload the webserver. There is no need to restart docker compose.</p>
+			  </div>
+			  <div class="modal-footer">
+				<button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+			  </div>
+			</div>
+		  </div>
+		</div>
 
 		<?php echo loadClass('Html')->getFooter(); ?>
 		<script>

--- a/.devilbox/www/include/lib/container/Httpd.php
+++ b/.devilbox/www/include/lib/container/Httpd.php
@@ -71,7 +71,7 @@ class Httpd extends BaseClass implements BaseInterface
 
 		if ($handle = opendir($docRoot)) {
 			while (false !== ($directory = readdir($handle))) {
-				if ($this->_is_valid_dir($docRoot . DIRECTORY_SEPARATOR . $directory) && $directory != '.' && $directory != '..') {
+				if ($this->_is_valid_dir($docRoot . DIRECTORY_SEPARATOR . $directory) && $directory[0] != '.' ) {
 
 					$vhosts[$directory] = array(
 						'name'		=> $directory,

--- a/.devilbox/www/include/vendor/Mail/Mbox.php
+++ b/.devilbox/www/include/vendor/Mail/Mbox.php
@@ -190,6 +190,12 @@ class Mail_Mbox extends PEAR
     var $autoReopen = true;
 
 
+	/**
+	 * cytoia added to prevent deprecation warning about dynamically creating
+	 * this variable inside the constructor
+	 */
+	var $_file = null;
+
 
     /**
      * Create a new Mbox class instance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Make sure to have a look at [UPDATING.md](https://github.com/cytopia/devilbox/bl
 ## Unreleased
 
 
+## Release v3.0.0-beta-0.4 (2022-01-30)
+
+### Fixed
+- Ignore directories starting with a `.` in `/shared/httpd` (invalid server names)
+- Fixed: `Creation of dynamic property Mail_Mbox::$_file is deprecated` (PHP 8.2)
+- Fixed: Xdebug default configuration files in cfg/php-ini-X.Y/devilbox-php.ini-xdebug [#866](https://github.com/cytopia/devilbox/issues/866)
+- Fixed: Show httpd access logs via docker logs when `DOCKER_LOGS=1` instead of piping it to supervisord [#956](https://github.com/cytopia/devilbox/issues/956)
+
+### Added
+- Intranet: Allow to reload PHP-FPM to reflect `php.ini` or `php-fpm.conf` changes on-the-fly without restarting docker-compose
+
+### Changed
+- Updated httpd images
+- Updated php-fpm images
+
+
 ## Release v3.0.0-beta-0.3 (2022-01-02)
 
 This release provides the `dvl.to` domain to be used with `TLD_SUFFIX` (set to default), which eliminates the need to set any entries in `/etc/hosts`, as all of its subdomain will point to `127.0.0.1` via official DNS. Domain has been acquired thanks to awesome sponsors!

--- a/cfg/php-ini-5.2/devilbox-php.ini-xdebug
+++ b/cfg/php-ini-5.2/devilbox-php.ini-xdebug
@@ -20,7 +20,8 @@
 ;
 [PHP]
 
-; Xdebug
+; Xdebug (version 2.2.7)
+;
 ; Use these settings to enable Xdebug for PHP
 ; Make sure to read up on Xdebug some settings might significantly slow down requests.
 ; The following is just an example configuration and should be adjusted

--- a/cfg/php-ini-5.3/devilbox-php.ini-xdebug
+++ b/cfg/php-ini-5.3/devilbox-php.ini-xdebug
@@ -20,7 +20,8 @@
 ;
 [PHP]
 
-; Xdebug
+; Xdebug (version 2.2.7)
+;
 ; Use these settings to enable Xdebug for PHP
 ; Make sure to read up on Xdebug some settings might significantly slow down requests.
 ; The following is just an example configuration and should be adjusted

--- a/cfg/php-ini-5.4/devilbox-php.ini-xdebug
+++ b/cfg/php-ini-5.4/devilbox-php.ini-xdebug
@@ -20,7 +20,8 @@
 ;
 [PHP]
 
-; Xdebug
+; Xdebug (version 2.4.1)
+;
 ; Use these settings to enable Xdebug for PHP
 ; Make sure to read up on Xdebug some settings might significantly slow down requests.
 ; The following is just an example configuration and should be adjusted

--- a/cfg/php-ini-5.5/devilbox-php.ini-xdebug
+++ b/cfg/php-ini-5.5/devilbox-php.ini-xdebug
@@ -20,7 +20,8 @@
 ;
 [PHP]
 
-; Xdebug
+; Xdebug (version 2.4.1)
+;
 ; Use these settings to enable Xdebug for PHP
 ; Make sure to read up on Xdebug some settings might significantly slow down requests.
 ; The following is just an example configuration and should be adjusted

--- a/cfg/php-ini-5.6/devilbox-php.ini-xdebug
+++ b/cfg/php-ini-5.6/devilbox-php.ini-xdebug
@@ -20,7 +20,8 @@
 ;
 [PHP]
 
-; Xdebug
+; Xdebug (version 2.4.1)
+;
 ; Use these settings to enable Xdebug for PHP
 ; Make sure to read up on Xdebug some settings might significantly slow down requests.
 ; The following is just an example configuration and should be adjusted

--- a/cfg/php-ini-7.0/devilbox-php.ini-xdebug
+++ b/cfg/php-ini-7.0/devilbox-php.ini-xdebug
@@ -20,7 +20,8 @@
 ;
 [PHP]
 
-; Xdebug
+; Xdebug (version 2.9.0)
+;
 ; Use these settings to enable Xdebug for PHP
 ; Make sure to read up on Xdebug some settings might significantly slow down requests.
 ; The following is just an example configuration and should be adjusted

--- a/cfg/php-ini-7.1/devilbox-php.ini-xdebug
+++ b/cfg/php-ini-7.1/devilbox-php.ini-xdebug
@@ -20,7 +20,8 @@
 ;
 [PHP]
 
-; Xdebug
+; Xdebug (version 2.9.8)
+;
 ; Use these settings to enable Xdebug for PHP
 ; Make sure to read up on Xdebug some settings might significantly slow down requests.
 ; The following is just an example configuration and should be adjusted

--- a/cfg/php-ini-7.2/devilbox-php.ini-xdebug
+++ b/cfg/php-ini-7.2/devilbox-php.ini-xdebug
@@ -20,16 +20,32 @@
 ;
 [PHP]
 
-; Xdebug
-; https://3.xdebug.org/docs/upgrade_guide
+; Xdebug (version 3.1.6)
+; Upgrade Guide:  https://3.xdebug.org/docs/upgrade_guide
+; Settings Guide: https://xdebug.org/docs/all_settings
+;
 ; Use these settings to enable Xdebug for PHP
 ; Make sure to read up on Xdebug some settings might significantly slow down requests.
-; The following is just an example configuration and should be adjusted
+; The following is just an example configuration and should be adjusted.
+
+; Defaults
 xdebug.mode               = debug
+xdebug.remote_handler     = dbgp
 xdebug.start_with_request = yes
-xdebug.remote_handler   = dbgp
-xdebug.remote_port      = 9000
-xdebug.idekey           = PHPSTORM
-xdebug.remote_log       = /var/log/php/xdebug.log
+;xdebug.start_with_request = trigger
+;xdebug.trigger_value      = randomkey
+
+; How to connect
+xdebug.client_port          = 9000
+xdebug.client_host          = host.docker.internal
+xdebug.discover_client_host = 0
+
+; Logging
+xdebug.log       = /var/log/php/xdebug.log
+xdebug.log_level = 7
+
+; IDE Configuration
+xdebug.idekey    = PHPSTORM
+;xdebug.idekey    = VSCODE
 
 ; vim: set ft=dosini:

--- a/cfg/php-ini-7.3/devilbox-php.ini-xdebug
+++ b/cfg/php-ini-7.3/devilbox-php.ini-xdebug
@@ -20,16 +20,32 @@
 ;
 [PHP]
 
-; Xdebug
-; https://3.xdebug.org/docs/upgrade_guide
+; Xdebug (version 3.1.6)
+; Upgrade Guide:  https://3.xdebug.org/docs/upgrade_guide
+; Settings Guide: https://xdebug.org/docs/all_settings
+;
 ; Use these settings to enable Xdebug for PHP
 ; Make sure to read up on Xdebug some settings might significantly slow down requests.
-; The following is just an example configuration and should be adjusted
+; The following is just an example configuration and should be adjusted.
+
+; Defaults
 xdebug.mode               = debug
+xdebug.remote_handler     = dbgp
 xdebug.start_with_request = yes
-xdebug.remote_handler   = dbgp
-xdebug.remote_port      = 9000
-xdebug.idekey           = PHPSTORM
-xdebug.remote_log       = /var/log/php/xdebug.log
+;xdebug.start_with_request = trigger
+;xdebug.trigger_value      = randomkey
+
+; How to connect
+xdebug.client_port          = 9000
+xdebug.client_host          = host.docker.internal
+xdebug.discover_client_host = 0
+
+; Logging
+xdebug.log       = /var/log/php/xdebug.log
+xdebug.log_level = 7
+
+; IDE Configuration
+xdebug.idekey    = PHPSTORM
+;xdebug.idekey    = VSCODE
 
 ; vim: set ft=dosini:

--- a/cfg/php-ini-7.4/devilbox-php.ini-xdebug
+++ b/cfg/php-ini-7.4/devilbox-php.ini-xdebug
@@ -20,16 +20,32 @@
 ;
 [PHP]
 
-; Xdebug
-; https://3.xdebug.org/docs/upgrade_guide
+; Xdebug (version 3.1.6)
+; Upgrade Guide:  https://3.xdebug.org/docs/upgrade_guide
+; Settings Guide: https://xdebug.org/docs/all_settings
+;
 ; Use these settings to enable Xdebug for PHP
 ; Make sure to read up on Xdebug some settings might significantly slow down requests.
-; The following is just an example configuration and should be adjusted
+; The following is just an example configuration and should be adjusted.
+
+; Defaults
 xdebug.mode               = debug
+xdebug.remote_handler     = dbgp
 xdebug.start_with_request = yes
-xdebug.remote_handler   = dbgp
-xdebug.remote_port      = 9000
-xdebug.idekey           = PHPSTORM
-xdebug.remote_log       = /var/log/php/xdebug.log
+;xdebug.start_with_request = trigger
+;xdebug.trigger_value      = randomkey
+
+; How to connect
+xdebug.client_port          = 9000
+xdebug.client_host          = host.docker.internal
+xdebug.discover_client_host = 0
+
+; Logging
+xdebug.log       = /var/log/php/xdebug.log
+xdebug.log_level = 7
+
+; IDE Configuration
+xdebug.idekey    = PHPSTORM
+;xdebug.idekey    = VSCODE
 
 ; vim: set ft=dosini:

--- a/cfg/php-ini-8.0/devilbox-php.ini-xdebug
+++ b/cfg/php-ini-8.0/devilbox-php.ini-xdebug
@@ -20,16 +20,32 @@
 ;
 [PHP]
 
-; Xdebug
-; https://3.xdebug.org/docs/upgrade_guide
+; Xdebug (version 3.x.x - latest)
+; Upgrade Guide:  https://3.xdebug.org/docs/upgrade_guide
+; Settings Guide: https://xdebug.org/docs/all_settings
+;
 ; Use these settings to enable Xdebug for PHP
 ; Make sure to read up on Xdebug some settings might significantly slow down requests.
-; The following is just an example configuration and should be adjusted
+; The following is just an example configuration and should be adjusted.
+
+; Defaults
 xdebug.mode               = debug
-xdebug.start_with_request = yes
 xdebug.remote_handler     = dbgp
-xdebug.remote_port        = 9000
-xdebug.idekey             = PHPSTORM
-xdebug.remote_log         = /var/log/php/xdebug.log
+xdebug.start_with_request = yes
+;xdebug.start_with_request = trigger
+;xdebug.trigger_value      = randomkey
+
+; How to connect
+xdebug.client_port          = 9000
+xdebug.client_host          = host.docker.internal
+xdebug.discover_client_host = 0
+
+; Logging
+xdebug.log       = /var/log/php/xdebug.log
+xdebug.log_level = 7
+
+; IDE Configuration
+xdebug.idekey    = PHPSTORM
+;xdebug.idekey    = VSCODE
 
 ; vim: set ft=dosini:

--- a/cfg/php-ini-8.1/devilbox-php.ini-xdebug
+++ b/cfg/php-ini-8.1/devilbox-php.ini-xdebug
@@ -20,16 +20,32 @@
 ;
 [PHP]
 
-; Xdebug
-; https://3.xdebug.org/docs/upgrade_guide
+; Xdebug (version 3.x.x - latest)
+; Upgrade Guide:  https://3.xdebug.org/docs/upgrade_guide
+; Settings Guide: https://xdebug.org/docs/all_settings
+;
 ; Use these settings to enable Xdebug for PHP
 ; Make sure to read up on Xdebug some settings might significantly slow down requests.
-; The following is just an example configuration and should be adjusted
+; The following is just an example configuration and should be adjusted.
+
+; Defaults
 xdebug.mode               = debug
-xdebug.start_with_request = yes
 xdebug.remote_handler     = dbgp
-xdebug.remote_port        = 9000
-xdebug.idekey             = PHPSTORM
-xdebug.remote_log         = /var/log/php/xdebug.log
+xdebug.start_with_request = yes
+;xdebug.start_with_request = trigger
+;xdebug.trigger_value      = randomkey
+
+; How to connect
+xdebug.client_port          = 9000
+xdebug.client_host          = host.docker.internal
+xdebug.discover_client_host = 0
+
+; Logging
+xdebug.log       = /var/log/php/xdebug.log
+xdebug.log_level = 7
+
+; IDE Configuration
+xdebug.idekey    = PHPSTORM
+;xdebug.idekey    = VSCODE
 
 ; vim: set ft=dosini:

--- a/cfg/php-ini-8.2/devilbox-php.ini-xdebug
+++ b/cfg/php-ini-8.2/devilbox-php.ini-xdebug
@@ -20,16 +20,32 @@
 ;
 [PHP]
 
-; Xdebug
-; https://3.xdebug.org/docs/upgrade_guide
+; Xdebug (version 3.x.x - latest)
+; Upgrade Guide:  https://3.xdebug.org/docs/upgrade_guide
+; Settings Guide: https://xdebug.org/docs/all_settings
+;
 ; Use these settings to enable Xdebug for PHP
 ; Make sure to read up on Xdebug some settings might significantly slow down requests.
-; The following is just an example configuration and should be adjusted
+; The following is just an example configuration and should be adjusted.
+
+; Defaults
 xdebug.mode               = debug
-xdebug.start_with_request = yes
 xdebug.remote_handler     = dbgp
-xdebug.remote_port        = 9000
-xdebug.idekey             = PHPSTORM
-xdebug.remote_log         = /var/log/php/xdebug.log
+xdebug.start_with_request = yes
+;xdebug.start_with_request = trigger
+;xdebug.trigger_value      = randomkey
+
+; How to connect
+xdebug.client_port          = 9000
+xdebug.client_host          = host.docker.internal
+xdebug.discover_client_host = 0
+
+; Logging
+xdebug.log       = /var/log/php/xdebug.log
+xdebug.log_level = 7
+
+; IDE Configuration
+xdebug.idekey    = PHPSTORM
+;xdebug.idekey    = VSCODE
 
 ; vim: set ft=dosini:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
   # PHP
   # ------------------------------------------------------------
   php:
-    image: devilbox/php-fpm:${PHP_SERVER}-work-0.150
+    image: devilbox/php-fpm:${PHP_SERVER}-work-0.151
     hostname: php
 
     ##
@@ -116,6 +116,7 @@ services:
       ##
       ## Supervisord Management (to connect to HTTPD supvervisord)
       ##
+      - SVCTL_ENABLE=1
       - SVCTL_LISTEN_PORT=9001
       - SVCTL_USER=${DEVILBOX_HTTPD_MGMT_USER:-supervisor}
       - SVCTL_PASS=${DEVILBOX_HTTPD_MGMT_PASS:-mypassword}
@@ -229,7 +230,7 @@ services:
   # Web Server
   # ------------------------------------------------------------
   httpd:
-    image: devilbox/${HTTPD_SERVER}:${HTTPD_FLAVOUR:-alpine}-1.0
+    image: devilbox/${HTTPD_SERVER}:${HTTPD_FLAVOUR:-alpine}-1.2
     hostname: httpd
 
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,9 @@ services:
       - ./.env
 
     environment:
+      # Where PHP is looking for ini files
+      - PHP_INI_SCAN_DIR=/usr/local/etc/php/conf.d:/etc/php-custom.d
+
       ##
       ## Supervisord Management (to connect to HTTPD supvervisord)
       ##


### PR DESCRIPTION
# Release v3.0.0 beta 0.4
This release adds the ability to reload PHP configuration changes without having to restart docker compose. You can change any `*.ini` or `*.conf` files and then trigger a reload in the intranet.

### Fixed
* Ignore directories starting with a `.` in `/shared/httpd` (invalid server names)
* Fixed: `Creation of dynamic property Mail_Mbox::$_file is deprecated` (PHP 8.2)
* Fixed: Xdebug default configuration files in cfg/php-ini-X.Y/devilbox-php.ini-xdebug [#866](https://github.com/cytopia/devilbox/issues/866)
* Fixed: Show httpd access logs via docker logs when `DOCKER_LOGS=1` instead of piping it to supervisord [#956](https://github.com/cytopia/devilbox/issues/956)

### Added
* Intranet: Allow to reload PHP-FPM to reflect `php.ini` or `php-fpm.conf` changes on-the-fly without restarting docker-compose

### Changed
* Updated httpd images
* Updated php-fpm images

## PR / Issues
* Fixes [file devilbox-php.ini-xdebug not suitable for xdebug 3 #866](https://github.com/cytopia/devilbox/issues/866)
* Fixes [[Bug]: Docker Logging doesnt seem to work properly in v3.0.0-beta-0.3 #956](https://github.com/cytopia/devilbox/issues/956)